### PR TITLE
Add TutorialSearch to Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Just send a pull request or open an [issue](https://github.com/nqcm/learning-blo
 1. [Learning Solidity Tutorials on Youtube](https://www.youtube.com/playlist?list=PL16WqdAj66SCOdL6XIFbke-XQg2GW_Avg)
 1. [Beginners' Guide to Smart Contracts in Solidity](https://www.youtube.com/watch?v=R_CiemcFKis&list=PLQeiVDgMaJcWnAZLElXKLZhS5a71Sxzw0)
 1. [Create Your Own Ethereum Blockchain](https://www.youtube.com/watch?v=SKXYYnmjauQ&list=PLQeiVDgMaJcVYH3hH29lgBpxog9S82o6a)
+2. [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 ## Articles and Blogs
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Just send a pull request or open an [issue](https://github.com/nqcm/learning-blo
 1. [Learning Solidity Tutorials on Youtube](https://www.youtube.com/playlist?list=PL16WqdAj66SCOdL6XIFbke-XQg2GW_Avg)
 1. [Beginners' Guide to Smart Contracts in Solidity](https://www.youtube.com/watch?v=R_CiemcFKis&list=PLQeiVDgMaJcWnAZLElXKLZhS5a71Sxzw0)
 1. [Create Your Own Ethereum Blockchain](https://www.youtube.com/watch?v=SKXYYnmjauQ&list=PLQeiVDgMaJcVYH3hH29lgBpxog9S82o6a)
-2. [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+2. [TutorialSearch](https://tutorialsearch.io/browse/blockchain-web3/blockchain-analytics) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 ## Articles and Blogs
 


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Tutorials* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/blockchain-web3/blockchain-analytics) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/blockchain-web3/blockchain-analytics) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.